### PR TITLE
Day 14 Text wrapping in Python

### DIFF
--- a/Day 14 Text wrapping in Python.ipynb
+++ b/Day 14 Text wrapping in Python.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2a7b860f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This function wraps the input paragraph such that each line\n",
+      "in the paragraph is at most width characters long.The wrap\n",
+      "method  returns a list of output lines . The returned list\n",
+      "is empty if the wrapped output has no content.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import textwrap\n",
+    "value =\"\"\"This function wraps the input paragraph such that each line\n",
+    "in the paragraph is at most width characters long.The wrap method \n",
+    "returns a list of output lines . The returned list \n",
+    "is empty if the wrapped\n",
+    "output has no content.\"\"\" \n",
+    "\n",
+    "\n",
+    "# Wrap this text .\n",
+    "wrapper = textwrap.TextWrapper(width =60)\n",
+    "\n",
+    "word_list = wrapper.wrap(text=value)\n",
+    "\n",
+    "# Print each Line .\n",
+    "for element in word_list:\n",
+    "    print(element)\n",
+    "\n",
+    "#Tahir 365"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef1c4f33",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Day 14 Text wrapping in Pyth The textwrap module can be used for wrapping and formatting of plain text. This module provides formatting of text by adjusting the line breaks in the input paragraph.

The TextWrapper instance attributes (and keyword arguments to the constructor) are as follows:

width: This refers to the maximum length allowed of the wrapped lines. It’s default value is set to 70.
expand_tabs: It’s default value is set to TRUE. If the value is equal to true, then, all the tab characters in the sample input is expanded to spaces using this method.
tabsize: It’s default value is set to 8. This method expands all tab characters in text to zero or more spaces, depending on the current column and the given tab size, if the value of expand_tabs is TRUE.
replace_whitespace: It’s default value is set to TRUE. If the value is true, after tab expansion but before wrapping, the wrap() method replaces each whitespace character with a single space.These whitespace characters are replaced : tab, newline, vertical tab, formfeed, and carriage return (‘\t\n\v\f\r’).on