### PR TITLE
Day 130  Group Elements of Same Indices using Python

### DIFF
--- a/Day 130  Group Elements of Same Indices using Python.ipynb
+++ b/Day 130  Group Elements of Same Indices using Python.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d9f1e80d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10, 40, 70] [20, 50, 80] [30, 60, 90]\n"
+     ]
+    }
+   ],
+   "source": [
+    "inputLists = [[10, 20, 30], [40, 50, 60], [70, 80, 90]]\n",
+    "outputLists = []\n",
+    "index = 0\n",
+    "\n",
+    "for i in range(len(inputLists[0])):\n",
+    "    outputLists.append([])\n",
+    "    for j in range(len(inputLists)):\n",
+    "        outputLists[index].append(inputLists[j][ index])\n",
+    "    index = index + 1\n",
+    "a, b, c = outputLists[0], outputLists[1], outputLists[2]\n",
+    "print(a, b, c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8588465",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Group Elements of Same Indices using Python
To group elements of the same index, you will initially have two or more lists inside a list like [[a, b], [c, d]]. To group the elements of these lists, you need to create two new lists where you will store the elements of both the lists at index 0 [a, c] and index 1 [b, d]. That is the meaning of grouping the elements of the same indices.

Now below is how you can group the elements of the same indices using the Python programming language:

So this is how you can group the items of the same indices using Python. Find many more coding questions and projects solved and explained using Python here.

Summary
To group items of the same indices, you will initially have two or more lists inside a list like [[a, b], [c, d]], and you need to create two new lists where you will store the elements of both the lists at index 0 [a, c] and index 1 [b, d]. I hope you liked this article on grouping the elements of the same indices using Python.