### PR TITLE
Day 133 Count Number of Words in a Column using Python

### DIFF
--- a/Day 133 Count Number of Words in a Column using Python.ipynb
+++ b/Day 133 Count Number of Words in a Column using Python.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "96a3979d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             Article  \\\n",
+      "0  Data analysis is the process of inspecting and...   \n",
+      "1  The performance of a machine learning algorith...   \n",
+      "2  You must have seen the news divided into categ...   \n",
+      "3  When there are only two classes in a classific...   \n",
+      "4  The Multinomial Naive Bayes is one of the vari...   \n",
+      "\n",
+      "                                               Title  \n",
+      "0                  Best Books to Learn Data Analysis  \n",
+      "1         Assumptions of Machine Learning Algorithms  \n",
+      "2          News Classification with Machine Learning  \n",
+      "3  Multiclass Classification Algorithms in Machin...  \n",
+      "4        Multinomial Naive Bayes in Machine Learning  \n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "data = pd.read_csv(\"https://raw.githubusercontent.com/amankharwal/Website-data/master/articles.csv\", encoding = 'latin1')\n",
+    "print(data.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4fa82d78",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                             Article  \\\n",
+      "0  Data analysis is the process of inspecting and...   \n",
+      "1  The performance of a machine learning algorith...   \n",
+      "2  You must have seen the news divided into categ...   \n",
+      "3  When there are only two classes in a classific...   \n",
+      "4  The Multinomial Naive Bayes is one of the vari...   \n",
+      "\n",
+      "                                               Title  Number of Words  \n",
+      "0                  Best Books to Learn Data Analysis               76  \n",
+      "1         Assumptions of Machine Learning Algorithms               56  \n",
+      "2          News Classification with Machine Learning               70  \n",
+      "3  Multiclass Classification Algorithms in Machin...               66  \n",
+      "4        Multinomial Naive Bayes in Machine Learning               96  \n"
+     ]
+    }
+   ],
+   "source": [
+    "data[\"Number of Words\"] = data[\"Article\"].apply(lambda n: len(n.split()))\n",
+    "print(data.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72aa2a22",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
While working on a Data Science task, sometimes we have to deal with textual data. One of the problems beginners face while working on a textual dataset is counting the number of words in a piece of text. So if you want to learn how to count the number of words in a textual dataset, this article is for you.  I will take you through a tutorial on how to count the number of words in a column using Python.


Count Number of Words in a Column using Python

Most data science professionals use the pandas library for data handling and preparation. The pandas library doesn’t have any method to count the number of words in a piece of text. One way to solve this problem is by finding the length of the text by splitting the complete text.

So let’s import a textual dataset where we can count the number of words in a column:

So the dataset has three columns now, Article, Title and the Number of Words that contains the number of words in the article column.

Summary
The pandas library doesn’t have any method to count the number of words in a piece of text. One way to solve this problem is by finding the length of the text by splitting the complete text. So, this is how you can count the number of words in any column while working on a textual dataset. I hope you liked this article on counting the number of words in a column using Python. Feel free to ask valuable questions in the comments section below.