### PR TITLE
Day 137 Generate Text using Python

### DIFF
--- a/Day 137 Generate Text using Python.ipynb
+++ b/Day 137 Generate Text using Python.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "62590577",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The cache for model files in Transformers v4.22.0 has been updated. Migrating your old cache. This is a one-time only operation. You can interrupt this and resume the migration later on by calling `transformers.utils.move_cache()`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Moving 0 files to the new cache system\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": {
+       "ascii": false,
+       "bar_format": null,
+       "colour": null,
+       "elapsed": 0.022484779357910156,
+       "initial": 0,
+       "n": 0,
+       "ncols": null,
+       "nrows": 29,
+       "postfix": null,
+       "prefix": "",
+       "rate": null,
+       "total": 0,
+       "unit": "it",
+       "unit_divisor": 1000,
+       "unit_scale": false
+      },
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "16f4d00811ac44f08684c07c9963d330",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "0it [00:00, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\UseR\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\scipy\\__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.23.4\n",
+      "  warnings.warn(f\"A NumPy version >={np_minversion} and <{np_maxversion}\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import pipeline\n",
+    "model = pipeline(\"text-generation\", model = \"gpt2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "45cace7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "The following `model_kwargs` are not used by the model: ['num_return_sentences'] (note: typos in the generate arguments will also show up in this list)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn [2], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m sentence \u001b[38;5;241m=\u001b[39m model(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mHi, My name is John Cena, I am here\u001b[39m\u001b[38;5;124m\"\u001b[39m, \n\u001b[0;32m      2\u001b[0m                  do_sample\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, top_k\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m50\u001b[39m, \n\u001b[0;32m      3\u001b[0m                  temperature\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0.9\u001b[39m, max_length\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m100\u001b[39m, \n\u001b[0;32m      4\u001b[0m                  num_return_sentences\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m)\n\u001b[0;32m      6\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m sentence:\n\u001b[0;32m      7\u001b[0m   \u001b[38;5;28mprint\u001b[39m(i[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mgenerated_text\u001b[39m\u001b[38;5;124m\"\u001b[39m])\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\pipelines\\text_generation.py:187\u001b[0m, in \u001b[0;36mTextGenerationPipeline.__call__\u001b[1;34m(self, text_inputs, **kwargs)\u001b[0m\n\u001b[0;32m    148\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, text_inputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[0;32m    149\u001b[0m     \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m    150\u001b[0m \u001b[38;5;124;03m    Complete the prompt(s) given as inputs.\u001b[39;00m\n\u001b[0;32m    151\u001b[0m \n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    185\u001b[0m \u001b[38;5;124;03m          ids of the generated text.\u001b[39;00m\n\u001b[0;32m    186\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m--> 187\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__call__\u001b[39m(text_inputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\pipelines\\base.py:1074\u001b[0m, in \u001b[0;36mPipeline.__call__\u001b[1;34m(self, inputs, num_workers, batch_size, *args, **kwargs)\u001b[0m\n\u001b[0;32m   1072\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39miterate(inputs, preprocess_params, forward_params, postprocess_params)\n\u001b[0;32m   1073\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m-> 1074\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_single\u001b[49m\u001b[43m(\u001b[49m\u001b[43minputs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreprocess_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mforward_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpostprocess_params\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\pipelines\\base.py:1081\u001b[0m, in \u001b[0;36mPipeline.run_single\u001b[1;34m(self, inputs, preprocess_params, forward_params, postprocess_params)\u001b[0m\n\u001b[0;32m   1079\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mrun_single\u001b[39m(\u001b[38;5;28mself\u001b[39m, inputs, preprocess_params, forward_params, postprocess_params):\n\u001b[0;32m   1080\u001b[0m     model_inputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpreprocess(inputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mpreprocess_params)\n\u001b[1;32m-> 1081\u001b[0m     model_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mforward(model_inputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mforward_params)\n\u001b[0;32m   1082\u001b[0m     outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpostprocess(model_outputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mpostprocess_params)\n\u001b[0;32m   1083\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m outputs\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\pipelines\\base.py:990\u001b[0m, in \u001b[0;36mPipeline.forward\u001b[1;34m(self, model_inputs, **forward_params)\u001b[0m\n\u001b[0;32m    988\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m inference_context():\n\u001b[0;32m    989\u001b[0m         model_inputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_ensure_tensor_on_device(model_inputs, device\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdevice)\n\u001b[1;32m--> 990\u001b[0m         model_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward(model_inputs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mforward_params)\n\u001b[0;32m    991\u001b[0m         model_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_ensure_tensor_on_device(model_outputs, device\u001b[38;5;241m=\u001b[39mtorch\u001b[38;5;241m.\u001b[39mdevice(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcpu\u001b[39m\u001b[38;5;124m\"\u001b[39m))\n\u001b[0;32m    992\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\pipelines\\text_generation.py:229\u001b[0m, in \u001b[0;36mTextGenerationPipeline._forward\u001b[1;34m(self, model_inputs, **generate_kwargs)\u001b[0m\n\u001b[0;32m    227\u001b[0m prompt_text \u001b[38;5;241m=\u001b[39m model_inputs\u001b[38;5;241m.\u001b[39mpop(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprompt_text\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m    228\u001b[0m \u001b[38;5;66;03m# BS x SL\u001b[39;00m\n\u001b[1;32m--> 229\u001b[0m generated_sequence \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel\u001b[38;5;241m.\u001b[39mgenerate(input_ids\u001b[38;5;241m=\u001b[39minput_ids, attention_mask\u001b[38;5;241m=\u001b[39mattention_mask, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mgenerate_kwargs)\n\u001b[0;32m    230\u001b[0m out_b \u001b[38;5;241m=\u001b[39m generated_sequence\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m0\u001b[39m]\n\u001b[0;32m    231\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mframework \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpt\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\torch\\autograd\\grad_mode.py:27\u001b[0m, in \u001b[0;36m_DecoratorContextManager.__call__.<locals>.decorate_context\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m     24\u001b[0m \u001b[38;5;129m@functools\u001b[39m\u001b[38;5;241m.\u001b[39mwraps(func)\n\u001b[0;32m     25\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mdecorate_context\u001b[39m(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs):\n\u001b[0;32m     26\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclone():\n\u001b[1;32m---> 27\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m func(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\generation_utils.py:1207\u001b[0m, in \u001b[0;36mGenerationMixin.generate\u001b[1;34m(self, inputs, max_length, min_length, do_sample, early_stopping, num_beams, temperature, top_k, top_p, typical_p, repetition_penalty, bad_words_ids, force_words_ids, bos_token_id, pad_token_id, eos_token_id, length_penalty, no_repeat_ngram_size, encoder_no_repeat_ngram_size, num_return_sequences, max_time, max_new_tokens, decoder_start_token_id, use_cache, num_beam_groups, diversity_penalty, prefix_allowed_tokens_fn, logits_processor, renormalize_logits, stopping_criteria, constraints, output_attentions, output_hidden_states, output_scores, return_dict_in_generate, forced_bos_token_id, forced_eos_token_id, remove_invalid_values, synced_gpus, exponential_decay_length_penalty, suppress_tokens, begin_suppress_tokens, forced_decoder_ids, **model_kwargs)\u001b[0m\n\u001b[0;32m   1205\u001b[0m \u001b[38;5;66;03m# 0. Validate the `.generate()` call\u001b[39;00m\n\u001b[0;32m   1206\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_validate_model_class()\n\u001b[1;32m-> 1207\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_validate_model_kwargs\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodel_kwargs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcopy\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1209\u001b[0m \u001b[38;5;66;03m# 1. Set generation parameters if not already defined\u001b[39;00m\n\u001b[0;32m   1210\u001b[0m bos_token_id \u001b[38;5;241m=\u001b[39m bos_token_id \u001b[38;5;28;01mif\u001b[39;00m bos_token_id \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconfig\u001b[38;5;241m.\u001b[39mbos_token_id\n",
+      "File \u001b[1;32m~\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\site-packages\\transformers\\generation_utils.py:909\u001b[0m, in \u001b[0;36mGenerationMixin._validate_model_kwargs\u001b[1;34m(self, model_kwargs)\u001b[0m\n\u001b[0;32m    906\u001b[0m         unused_model_args\u001b[38;5;241m.\u001b[39mappend(key)\n\u001b[0;32m    908\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m unused_model_args:\n\u001b[1;32m--> 909\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[0;32m    910\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe following `model_kwargs` are not used by the model: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munused_model_args\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m (note: typos in the\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    911\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m generate arguments will also show up in this list)\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    912\u001b[0m     )\n",
+      "\u001b[1;31mValueError\u001b[0m: The following `model_kwargs` are not used by the model: ['num_return_sentences'] (note: typos in the generate arguments will also show up in this list)"
+     ]
+    }
+   ],
+   "source": [
+    "sentence = model(\"Hi, My name is John Cena, I am here\", \n",
+    "                 do_sample=True, top_k=50, \n",
+    "                 temperature=0.9, max_length=100, \n",
+    "                 num_return_sentences=2)\n",
+    "\n",
+    "for i in sentence:\n",
+    "  print(i[\"generated_text\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4391c47",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Text generation involves generating text using machine learning techniques. The purpose of text generation is to automatically generate text that is indistinguishable from a text written by a human. If you want to learn how to generate text with Python, In this article, I will walk you through how to use the popular GPT-2 text generation model to generate text using Python.

What is GPT-2 Model?

GPT-2 stands for Generative Pre-trained Transformer 2. It is an open-source Natural Language Processing model created by OpenAI. It can generate paragraphs of text with state of the art performance on many language benchmarks. It is also used for machine translation, question answering, and text summarization.

To use the GPT-2 model to generate text using Python, you need to install the Transformers library in Python. It can be easily installed using the pip command on your command prompt or terminal as mentioned below:

pip install transformers

I hope you now understand what the GPT-2 model is and how you can install it in your Python virtual environment. You can read more about this model here. Now in the section below, I’ll explain how you can use this model for generating text using Python.

Generate Text using Python
Let’s import the GPT-2 model from the transformers library and start with the task of generating text using Python:


Summary
The purpose of text generation is to automatically generate text that is indistinguishable from text written by a human. GPT-2 is an open-source Natural Language Processing model created by OpenAI. It can generate paragraphs of text with state of the art performance on many language benchmarks. I hope you liked this article on generating text using Python and the GPT-2 model. Feel free to ask valuable questions in the comments section below.