### PR TITLE
Day 140 Create Dummy Data using Python

### DIFF
--- a/Day 140 Create Dummy Data using Python.ipynb
+++ b/Day 140 Create Dummy Data using Python.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "777c6c2e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matthew Mcdaniel\n",
+      "20190 Mathews Parkways\n",
+      "West Nathanstad, FL 35627\n",
+      "Note answer peace partner night. Spend beyond interview listen far. House husband role woman though push.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from faker import Faker\n",
+    "fake = Faker()\n",
+    "print(fake.name())\n",
+    "print(fake.address())\n",
+    "print(fake.text())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "21fdd001",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                              job                     company          ssn  \\\n",
+      "0  Furniture conservator/restorer                   Berry Ltd  248-39-1343   \n",
+      "1         Water quality scientist                  Miller LLC  305-16-7503   \n",
+      "2                     Fine artist  Swanson, Dixon and Fischer  521-32-5657   \n",
+      "3        Teacher, early years/pre   Berry, Phillips and Garza  153-67-3548   \n",
+      "4      Engineer, maintenance (IT)        Webb, Kelly and Rios  366-21-1955   \n",
+      "\n",
+      "                                           residence  \\\n",
+      "0          685 Michael Islands\\nSandrafort, CO 29768   \n",
+      "1   6928 Dave Viaduct Apt. 978\\nSouth Evan, LA 37652   \n",
+      "2  315 Calhoun Lock Suite 048\\nJenkinsland, SC 34289   \n",
+      "3   6283 Andre Club Suite 537\\nAllisontown, AK 20032   \n",
+      "4        5065 Tapia Harbor\\nNorth Dawnport, CT 45934   \n",
+      "\n",
+      "            current_location blood_group  \\\n",
+      "0      (1.571294, -6.197441)          A-   \n",
+      "1  (69.3599655, -161.284873)         AB+   \n",
+      "2   (-60.524306, -92.175703)         AB-   \n",
+      "3    (-42.038424, 52.398064)         AB+   \n",
+      "4    (27.218602, 175.903573)          A-   \n",
+      "\n",
+      "                                             website        username  \\\n",
+      "0  [http://davis.info/, http://macdonald.com/, ht...         jason97   \n",
+      "1  [http://www.scott.com/, http://shepherd-martin...   georgerebecca   \n",
+      "2                         [https://www.bonilla.net/]  leonardvalerie   \n",
+      "3                            [http://hart-tran.com/]           nboyd   \n",
+      "4    [https://www.bonilla.com/, https://miller.com/]     walkerjames   \n",
+      "\n",
+      "             name sex                                          address  \\\n",
+      "0    Matthew Lynn   M                 PSC 7108, Box 4870\\nAPO AE 63793   \n",
+      "1  Edward Miranda   M         122 Ronald Avenue\\nHillborough, AL 44991   \n",
+      "2   Donald Miller   M                       USS Townsend\\nFPO AP 74659   \n",
+      "3  Michelle Burns   F  9195 Reed Islands Suite 316\\nPort Amy, ME 15629   \n",
+      "4    Kirk Ramirez   M    91724 Peterson Ridges\\nCalderonland, ND 65122   \n",
+      "\n",
+      "                        mail   birthdate  \n",
+      "0       hortoneric@gmail.com  1960-02-04  \n",
+      "1    hillrebecca@hotmail.com  1952-07-11  \n",
+      "2           lisa91@gmail.com  1937-09-16  \n",
+      "3  phillipcarter@hotmail.com  1908-09-17  \n",
+      "4          yholder@yahoo.com  1952-01-28  \n"
+     ]
+    }
+   ],
+   "source": [
+    "from faker import Faker\n",
+    "import pandas as pd\n",
+    "fake = Faker()\n",
+    "data = [fake.profile() for i in range(50)]\n",
+    "data = pd.DataFrame(data)\n",
+    "print(data.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3008ee5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
If you are learning Data Science and find it hard to create a dataset for practice from scratch, you can either download a dataset from Kaggle or create fake data. If you want to learn how to create a dummy dataset in just a few lines of code, this article is for you. I will take you through how to create dummy data using Python.

Create Dummy Data using Python
To create dummy data using Python, we can use the faker library. The faker library generates fake data randomly. If you have never used this library before, you can easily install it by using the pip command mentioned below in your command prompt or terminal:

pip install faker
Now let’s look at some examples of this library before creating a dummy dataset. The code below will return a fake name, address, and text randomly:


Every time you will run this code, you will get different results. Now let’s see how to create fake data for creating a dummy dataset using Python.

The Faker().profile() method returns fake data about job profiles containing 13 columns. So below is how you can create a dummy dataset using Python:

You can learn more about creating fake data using the faker library from here.

Summary
So this is how you can create a fake or dummy dataset using the Python programming language. If you want to work with better datasets, I will recommend visiting Kaggle. I hope you liked this article on creating dummy data using Python. Feel free to ask valuable questions in the comments section below.