### PR TITLE
Day 147 Price Elasticity of Demand using Python

### DIFF
--- a/Day 147 Price Elasticity of Demand using Python.ipynb
+++ b/Day 147 Price Elasticity of Demand using Python.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "181c953d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Demand  Price\n",
+      "0      20   2000\n",
+      "1      30   1800\n",
+      "2      31   1850\n",
+      "3      33   1700\n",
+      "4      30   1800\n",
+      "5      33   1700\n",
+      "6      35   1600\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "data = pd.DataFrame({\"Demand\": [20, 30, 31, 33, 30, 33, 35], \n",
+    "                     \"Price\": [2000, 1800, 1850, 1700, 1800, 1700, 1600]})\n",
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "67ba1b87",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Demand  Price  % Change in Demand  % Change in Price\n",
+      "0      20   2000                 NaN                NaN\n",
+      "1      30   1800            0.500000          -0.100000\n",
+      "2      31   1850            0.033333           0.027778\n",
+      "3      33   1700            0.064516          -0.081081\n",
+      "4      30   1800           -0.090909           0.058824\n",
+      "5      33   1700            0.100000          -0.055556\n",
+      "6      35   1600            0.060606          -0.058824\n"
+     ]
+    }
+   ],
+   "source": [
+    "data[\"% Change in Demand\"] = data[\"Demand\"].pct_change()\n",
+    "data[\"% Change in Price\"] = data[\"Price\"].pct_change()\n",
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "85db65a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   Demand  Price  % Change in Demand  % Change in Price  Price Elasticity\n",
+      "0      20   2000                 NaN                NaN               NaN\n",
+      "1      30   1800            0.500000          -0.100000         -5.000000\n",
+      "2      31   1850            0.033333           0.027778          1.200000\n",
+      "3      33   1700            0.064516          -0.081081         -0.795699\n",
+      "4      30   1800           -0.090909           0.058824         -1.545455\n",
+      "5      33   1700            0.100000          -0.055556         -1.800000\n",
+      "6      35   1600            0.060606          -0.058824         -1.030303\n"
+     ]
+    }
+   ],
+   "source": [
+    "data[\"Price Elasticity\"] = data[\"% Change in Demand\"] / data[\"% Change in Price\"]\n",
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6df137e0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Price is one of the most important factors influencing the demand for a product. Elasticity refers to the degree of response, and the price elasticity of demand refers to the degree of responsiveness of demand for a product due to the change in its price. We study the price elasticity of demand in economics, but if you want to learn how to calculate the price elasticity of demand using Python, I will give you a tutorial on calculating the price elasticity of demand using Python.

Price Elasticity of Demand
Price elasticity of demand refers to the degree of responsiveness of demand for a product to a change in price. Simply put, it means the degree to which the demand for a product changes with an increase or decrease in its price. For example, the demand for a product increases by 20% due to a 10% decrease in its price. This is what it means to change in demand with the change in the price of a product. And when you calculate the degree to which demand changes, it’s called the price elasticity of demand.

To calculate the price elasticity of demand, you have to use the formula mentioned below:

Percentage Change in Quantity Demanded / Percentage Change in the Price

I hope you now have understood what price elasticity means and how to calculate it. Now in the section below, I will take you through a tutorial on how to calculate, price elasticity of demand using Python.

Price Elasticity of Demand using Python
I will start the task of calculating price elasticity of demand using Python by creating a small dataset that should contain data about the change in the price and the demand for a product:

The first rows of this dataset contain the initial demand and price for a product, and the subsequent rows contain the change in demand and the change in the price of the product. Now our next step is to add two more columns as the Percentage change in Demand and Percentage change in Price by calculating them:

Now the last step is to calculate the price elasticity of demand (% Change in Demand / % Change in Price) by adding a new column to this data. Below is how you can calculate it using Python:

Summary
Price elasticity of demand refers to the degree of responsiveness of demand for a product to a change in price. Simply put, it means the degree to which the demand for a product changes with an increase or decrease in its price. I hope you liked this article on how to calculate the price elasticity of demand using Python. Feel free to ask your valuable questions in the comments section below.